### PR TITLE
Update to mesa-dist-win 24.3.2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: 'The mesa-dist-win release version to use'
     required: false
-    default: '23.3.3'
+    default: '24.3.2'
   build-type:
     description: 'The mesa-dist-win build type to use'
     required: false


### PR DESCRIPTION
This updates to https://github.com/pal1000/mesa-dist-win/releases/tag/24.3.2.
